### PR TITLE
feat: Yax 84 일일 업무 총합 및 일일 업무 평균 비교 그래프 구현

### DIFF
--- a/src/app/(app)/(member)/dashboard/_components/BarCards.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/BarCards.tsx
@@ -8,8 +8,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { CardAction } from "@/components/ui/card-action";
-import { ChartBarStacked } from "./chart/BarChart";
 import { ChartBarMultiple } from "./chart/MultipleBarChart";
+import { ChartBarStacked } from "./chart/StackedBarChart";
 
 export function BarCards() {
   return (

--- a/src/app/(app)/(member)/dashboard/_components/BarCards.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/BarCards.tsx
@@ -1,0 +1,46 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  //   CardAction,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CardAction } from "@/components/ui/card-action";
+import { ChartBarStacked } from "./chart/BarChart";
+import { ChartBarMultiple } from "./chart/MultipleBarChart";
+
+export function BarCards() {
+  return (
+    <div className='*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 px-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4'>
+      <div className='col-span-2'>
+        <ChartBarStacked />
+      </div>
+      <div className='col-span-2'>
+        <ChartBarMultiple />
+      </div>
+    </div>
+  );
+}
+
+// 사용 예시 (기존 코드에 맞게 조정하세요)
+export function ExampleCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>카드 제목</CardTitle>
+        <CardDescription>카드 설명 텍스트입니다.</CardDescription>
+      </CardHeader>
+      <CardAction>
+        <Button variant='outline' size='sm'>
+          취소
+        </Button>
+        <Button size='sm'>확인</Button>
+      </CardAction>
+      <CardFooter>
+        <p>카드 푸터 영역입니다.</p>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/app/(app)/(member)/dashboard/_components/chart/BarChart.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/chart/BarChart.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export const description = "A stacked bar chart with a legend";
+
+const chartData = [
+  { day: "FRI", email: 14, git: 10, docs: 3, teams: 5 },
+  { day: "SAT", email: 0, git: 0, docs: 0, teams: 0 },
+  { day: "SUN", email: 0, git: 0, docs: 0, teams: 0 },
+  { day: "MON", email: 15, git: 13, docs: 2, teams: 6 },
+  { day: "TUE", email: 13, git: 8, docs: 3, teams: 9 },
+  { day: "WED", email: 23, git: 6, docs: 4, teams: 6 },
+  { day: "THU", email: 18, git: 9, docs: 3, teams: 10 },
+];
+
+const chartConfig = {
+  email: {
+    label: "Email",
+    color: "hsl(var(--chart-1))",
+  },
+  git: {
+    label: "Git",
+    color: "hsl(var(--chart-2))",
+  },
+  docs: {
+    label: "Docs",
+    color: "hsl(var(--chart-3))",
+  },
+  teams: {
+    label: "Teams",
+    color: "hsl(var(--chart-4))",
+  },
+} satisfies ChartConfig;
+
+export function ChartBarStacked() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>일일 업무 활동</CardTitle>
+        <CardDescription>2025년 5월 25일 ~ 6월 12일</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig}>
+          <BarChart accessibilityLayer data={chartData}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey='day'
+              tickLine={false}
+              tickMargin={10}
+              axisLine={false}
+              tickFormatter={value => value.slice(0, 3)}
+            />
+            <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+            <ChartLegend content={<ChartLegendContent />} />
+            <Bar
+              dataKey='email'
+              stackId='a'
+              fill='var(--color-email)'
+              radius={[0, 0, 4, 4]}
+            />
+            <Bar dataKey='git' stackId='a' fill='var(--color-git)' />
+            <Bar dataKey='docs' stackId='a' fill='var(--color-docs)' />
+            <Bar
+              dataKey='teams'
+              stackId='a'
+              fill='var(--color-teams)'
+              radius={[4, 4, 0, 0]}
+            />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+      {/* <CardFooter className='flex-col items-start gap-2 text-sm'>
+        <div className='flex gap-2 leading-none font-medium'>
+          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+        </div>
+        <div className='text-muted-foreground leading-none'>
+          Showing total visitors for the last 6 months
+        </div>
+      </CardFooter> */}
+    </Card>
+  );
+}

--- a/src/app/(app)/(member)/dashboard/_components/chart/MultipleBarChart.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/chart/MultipleBarChart.tsx
@@ -22,48 +22,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useState } from "react";
+import { httpInterface } from "@/lib/api/httpInterface";
+import { ChartData, DataItem } from "@/types/statisticsType";
+import { useEffect, useState } from "react";
+import { transformChartData } from "./_utils/TransformData";
 
 export const description = "A multiple bar chart";
-
-const allChartData = {
-  email: [
-    { day: "FRI", email: 10, avg: 6 },
-    { day: "SAT", email: 0, avg: 0 },
-    { day: "SUN", email: 0, avg: 0.3 },
-    { day: "MON", email: 12, avg: 20 },
-    { day: "TUE", email: 14, avg: 12 },
-    { day: "WED", email: 17, avg: 7 },
-    { day: "THU", email: 19, avg: 4 },
-  ],
-  git: [
-    { day: "FRI", git: 10, avg: 8 },
-    { day: "SAT", git: 0, avg: 0 },
-    { day: "SUN", git: 0, avg: 0 },
-    { day: "MON", git: 13, avg: 10 },
-    { day: "TUE", git: 8, avg: 9 },
-    { day: "WED", git: 6, avg: 7 },
-    { day: "THU", git: 9, avg: 8 },
-  ],
-  docs: [
-    { day: "FRI", docs: 3, avg: 2.5 },
-    { day: "SAT", docs: 0, avg: 0 },
-    { day: "SUN", docs: 0, avg: 0 },
-    { day: "MON", docs: 2, avg: 2 },
-    { day: "TUE", docs: 3, avg: 3 },
-    { day: "WED", docs: 4, avg: 3.5 },
-    { day: "THU", docs: 3, avg: 3 },
-  ],
-  teams: [
-    { day: "FRI", teams: 5, avg: 4 },
-    { day: "SAT", teams: 0, avg: 0 },
-    { day: "SUN", teams: 0, avg: 0 },
-    { day: "MON", teams: 6, avg: 5 },
-    { day: "TUE", teams: 9, avg: 7 },
-    { day: "WED", teams: 6, avg: 6 },
-    { day: "THU", teams: 10, avg: 8 },
-  ],
-};
 
 const chartConfig = {
   email: {
@@ -88,12 +52,32 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
+const emptyChartData: ChartData = {
+  email: [],
+  git: [],
+  docs: [],
+  teams: [],
+};
+
 export function ChartBarMultiple() {
+  const [chartData, setChartData] = useState<ChartData>(emptyChartData);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const rawData = await httpInterface.getStaticUser<DataItem[]>();
+      const avgRawData = await httpInterface.getAvgStaticUser<DataItem[]>();
+      const transformed = transformChartData(rawData, avgRawData);
+      setChartData(transformed);
+    };
+
+    fetchData();
+  }, []);
+
   const [filter, setFilter] = useState<"email" | "git" | "docs" | "teams">(
     "email"
   );
 
-  const filteredData = allChartData[filter];
+  const filteredData = chartData[filter];
 
   return (
     <Card>

--- a/src/app/(app)/(member)/dashboard/_components/chart/MultipleBarChart.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/chart/MultipleBarChart.tsx
@@ -23,9 +23,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { httpInterface } from "@/lib/api/httpInterface";
-import { ChartData, DataItem } from "@/types/statisticsType";
+import { DataItem, MultipleBarChartData } from "@/types/statisticsType";
 import { useEffect, useState } from "react";
-import { transformChartData } from "./_utils/TransformData";
+import { transformToAvgChartData } from "./_utils/TransformData";
 
 export const description = "A multiple bar chart";
 
@@ -52,7 +52,7 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-const emptyChartData: ChartData = {
+const emptyChartData: MultipleBarChartData = {
   email: [],
   git: [],
   docs: [],
@@ -60,13 +60,14 @@ const emptyChartData: ChartData = {
 };
 
 export function ChartBarMultiple() {
-  const [chartData, setChartData] = useState<ChartData>(emptyChartData);
+  const [chartData, setChartData] =
+    useState<MultipleBarChartData>(emptyChartData);
 
   useEffect(() => {
     const fetchData = async () => {
       const rawData = await httpInterface.getStaticUser<DataItem[]>();
       const avgRawData = await httpInterface.getAvgStaticUser<DataItem[]>();
-      const transformed = transformChartData(rawData, avgRawData);
+      const transformed = transformToAvgChartData(rawData, avgRawData);
       setChartData(transformed);
     };
 

--- a/src/app/(app)/(member)/dashboard/_components/chart/MultipleBarChart.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/chart/MultipleBarChart.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useState } from "react";
+
+export const description = "A multiple bar chart";
+
+const allChartData = {
+  email: [
+    { day: "FRI", email: 10, avg: 6 },
+    { day: "SAT", email: 0, avg: 0 },
+    { day: "SUN", email: 0, avg: 0.3 },
+    { day: "MON", email: 12, avg: 20 },
+    { day: "TUE", email: 14, avg: 12 },
+    { day: "WED", email: 17, avg: 7 },
+    { day: "THU", email: 19, avg: 4 },
+  ],
+  git: [
+    { day: "FRI", git: 10, avg: 8 },
+    { day: "SAT", git: 0, avg: 0 },
+    { day: "SUN", git: 0, avg: 0 },
+    { day: "MON", git: 13, avg: 10 },
+    { day: "TUE", git: 8, avg: 9 },
+    { day: "WED", git: 6, avg: 7 },
+    { day: "THU", git: 9, avg: 8 },
+  ],
+  docs: [
+    { day: "FRI", docs: 3, avg: 2.5 },
+    { day: "SAT", docs: 0, avg: 0 },
+    { day: "SUN", docs: 0, avg: 0 },
+    { day: "MON", docs: 2, avg: 2 },
+    { day: "TUE", docs: 3, avg: 3 },
+    { day: "WED", docs: 4, avg: 3.5 },
+    { day: "THU", docs: 3, avg: 3 },
+  ],
+  teams: [
+    { day: "FRI", teams: 5, avg: 4 },
+    { day: "SAT", teams: 0, avg: 0 },
+    { day: "SUN", teams: 0, avg: 0 },
+    { day: "MON", teams: 6, avg: 5 },
+    { day: "TUE", teams: 9, avg: 7 },
+    { day: "WED", teams: 6, avg: 6 },
+    { day: "THU", teams: 10, avg: 8 },
+  ],
+};
+
+const chartConfig = {
+  email: {
+    label: "Email",
+    color: "hsl(var(--chart-3))",
+  },
+  git: {
+    label: "Git",
+    color: "hsl(var(--chart-3))",
+  },
+  docs: {
+    label: "Docs",
+    color: "hsl(var(--chart-3))",
+  },
+  teams: {
+    label: "Teams",
+    color: "hsl(var(--chart-3))",
+  },
+  avg: {
+    label: "Average",
+    color: "hsl(var(--chart-1))",
+  },
+} satisfies ChartConfig;
+
+export function ChartBarMultiple() {
+  const [filter, setFilter] = useState<"email" | "git" | "docs" | "teams">(
+    "email"
+  );
+
+  const filteredData = allChartData[filter];
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className='flex justify-between items-center'>
+          <div>
+            <CardTitle>일일 업무 활동</CardTitle>
+            <CardDescription>{`${filter.toUpperCase()} 활동`}</CardDescription>
+          </div>
+          <div className='w-[160px]'>
+            <Select
+              value={filter}
+              onValueChange={value => setFilter(value as any)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='email'>Email</SelectItem>
+                <SelectItem value='git'>Git</SelectItem>
+                <SelectItem value='docs'>Docs</SelectItem>
+                <SelectItem value='teams'>Teams</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig}>
+          <BarChart accessibilityLayer data={filteredData}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey='day'
+              tickLine={false}
+              tickMargin={10}
+              axisLine={false}
+              tickFormatter={value => value.slice(0, 3)}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={<ChartTooltipContent indicator='dashed' />}
+            />
+            <Bar dataKey={filter} fill={`var(--color-${filter})`} radius={4} />
+            <Bar dataKey='avg' fill='var(--color-avg)' radius={4} />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+      {/* <CardFooter className='flex-col items-start gap-2 text-sm'>
+        <div className='flex gap-2 leading-none font-medium'>
+          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+        </div>
+        <div className='text-muted-foreground leading-none'>
+          Showing total visitors for the last 6 months
+        </div>
+      </CardFooter> */}
+    </Card>
+  );
+}

--- a/src/app/(app)/(member)/dashboard/_components/chart/StackedBarChart.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/chart/StackedBarChart.tsx
@@ -63,7 +63,7 @@ export function ChartBarStacked() {
     <Card>
       <CardHeader>
         <CardTitle>일일 업무 활동</CardTitle>
-        <CardDescription>2025년 5월 25일 ~ 6월 12일</CardDescription>
+        <CardDescription>개인 업무 총합</CardDescription>
       </CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig}>

--- a/src/app/(app)/(member)/dashboard/_components/chart/StackedBarChart.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/chart/StackedBarChart.tsx
@@ -17,18 +17,12 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { httpInterface } from "@/lib/api/httpInterface";
+import { DataItem, StackedBarChartData } from "@/types/statisticsType";
+import { useEffect, useState } from "react";
+import { aggregateToWeekdayChart } from "./_utils/TransformData";
 
 export const description = "A stacked bar chart with a legend";
-
-const chartData = [
-  { day: "FRI", email: 14, git: 10, docs: 3, teams: 5 },
-  { day: "SAT", email: 0, git: 0, docs: 0, teams: 0 },
-  { day: "SUN", email: 0, git: 0, docs: 0, teams: 0 },
-  { day: "MON", email: 15, git: 13, docs: 2, teams: 6 },
-  { day: "TUE", email: 13, git: 8, docs: 3, teams: 9 },
-  { day: "WED", email: 23, git: 6, docs: 4, teams: 6 },
-  { day: "THU", email: 18, git: 9, docs: 3, teams: 10 },
-];
 
 const chartConfig = {
   email: {
@@ -49,7 +43,22 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
+const emptyChartData: StackedBarChartData[] = [];
+
 export function ChartBarStacked() {
+  const [chartData, setChartData] =
+    useState<StackedBarChartData[]>(emptyChartData);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const rawData = await httpInterface.getStaticUser<DataItem[]>();
+      const transformed = aggregateToWeekdayChart(rawData);
+      setChartData(transformed);
+    };
+
+    fetchData();
+  }, []);
+
   return (
     <Card>
       <CardHeader>

--- a/src/app/(app)/(member)/dashboard/_components/chart/_utils/TransformData.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/chart/_utils/TransformData.tsx
@@ -1,11 +1,15 @@
-import { ChartData, DataItem } from "@/types/statisticsType";
+import {
+  DataItem,
+  MultipleBarChartData,
+  StackedBarChartData,
+} from "@/types/statisticsType";
 
 const weekDays = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
-export function transformChartData(
+export function transformToAvgChartData(
   actualData: DataItem[],
   averageData: DataItem[]
-): ChartData {
+): MultipleBarChartData {
   return {
     email: actualData.map((item, idx) => {
       const day = weekDays[new Date(item.report_date).getDay()];
@@ -43,4 +47,30 @@ export function transformChartData(
       return { day, teams: value, avg };
     }),
   };
+}
+
+export function aggregateToWeekdayChart(
+  data: DataItem[]
+): StackedBarChartData[] {
+  // 초기화된 주간 데이터 (일 ~ 토)
+  const summary: Record<string, StackedBarChartData> = weekDays.reduce(
+    (acc, day) => {
+      acc[day] = { day, email: 0, git: 0, docs: 0, teams: 0 };
+      return acc;
+    },
+    {} as Record<string, StackedBarChartData>
+  );
+
+  data.forEach(item => {
+    const day = weekDays[new Date(item.report_date).getDay()];
+
+    summary[day].email += item.email.receive + item.email.send;
+    summary[day].git +=
+      item.git.pull_request + item.git.commit + item.git.issue;
+    summary[day].docs +=
+      item.docs.docx + item.docs.xlsx + item.docs.txt + item.docs.etc;
+    summary[day].teams += item.teams.post;
+  });
+
+  return weekDays.map(day => summary[day]);
 }

--- a/src/app/(app)/(member)/dashboard/_components/chart/_utils/TransformData.tsx
+++ b/src/app/(app)/(member)/dashboard/_components/chart/_utils/TransformData.tsx
@@ -1,0 +1,46 @@
+import { ChartData, DataItem } from "@/types/statisticsType";
+
+const weekDays = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+export function transformChartData(
+  actualData: DataItem[],
+  averageData: DataItem[]
+): ChartData {
+  return {
+    email: actualData.map((item, idx) => {
+      const day = weekDays[new Date(item.report_date).getDay()];
+      const value = item.email.receive + item.email.send;
+      const avg = averageData[idx].email.receive + averageData[idx].email.send;
+      return { day, email: value, avg };
+    }),
+
+    git: actualData.map((item, idx) => {
+      const day = weekDays[new Date(item.report_date).getDay()];
+      const value = item.git.pull_request + item.git.commit + item.git.issue;
+      const avg =
+        averageData[idx].git.pull_request +
+        averageData[idx].git.commit +
+        averageData[idx].git.issue;
+      return { day, git: value, avg };
+    }),
+
+    docs: actualData.map((item, idx) => {
+      const day = weekDays[new Date(item.report_date).getDay()];
+      const value =
+        item.docs.docx + item.docs.xlsx + item.docs.txt + item.docs.etc;
+      const avg =
+        averageData[idx].docs.docx +
+        averageData[idx].docs.xlsx +
+        averageData[idx].docs.txt +
+        averageData[idx].docs.etc;
+      return { day, docs: value, avg };
+    }),
+
+    teams: actualData.map((item, idx) => {
+      const day = weekDays[new Date(item.report_date).getDay()];
+      const value = item.teams.post;
+      const avg = averageData[idx].teams.post;
+      return { day, teams: value, avg };
+    }),
+  };
+}

--- a/src/app/(app)/(member)/dashboard/page.tsx
+++ b/src/app/(app)/(member)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { BarCards } from "./_components/BarCards";
 import { SectionCards } from "./_components/SectionCards";
 
 export default function DashboardPage() {
@@ -6,6 +7,7 @@ export default function DashboardPage() {
       <div className='@container/main flex flex-1 flex-col gap-2'>
         <div className='flex flex-col gap-4 py-4 md:gap-6 md:py-6'>
           <SectionCards />
+          <BarCards />
           <div className='px-4 lg:px-6'>{/* <ChartAreaInteractive /> */}</div>
           {/* <DataTable data={data} /> */}
         </div>

--- a/src/lib/api/httpInterface.ts
+++ b/src/lib/api/httpInterface.ts
@@ -40,6 +40,14 @@ export class HttpInterface {
     return this.apiClient.delete<void>("/git");
   }
 
+  async getStaticUser<T>(): Promise<T> {
+    return this.apiClient.get<T>("/statics/user");
+  }
+
+  async getAvgStaticUser<T>(): Promise<T> {
+    return this.apiClient.get<T>("/statics/user/avg");
+  }
+
   // 여기에 다른 API 요청 메소드들을 추가할 수 있습니다.
   // 예시:
   // /**

--- a/src/types/statisticsType.ts
+++ b/src/types/statisticsType.ts
@@ -6,9 +6,17 @@ export interface DataItem {
   git: { pull_request: number; commit: number; issue: number };
 }
 
-export interface ChartData {
+export interface MultipleBarChartData {
   email: { day: string; email: number; avg: number }[];
   git: { day: string; git: number; avg: number }[];
   docs: { day: string; docs: number; avg: number }[];
   teams: { day: string; teams: number; avg: number }[];
+}
+
+export interface StackedBarChartData {
+  day: string;
+  email: number;
+  git: number;
+  docs: number;
+  teams: number;
 }

--- a/src/types/statisticsType.ts
+++ b/src/types/statisticsType.ts
@@ -1,0 +1,14 @@
+export interface DataItem {
+  report_date: string;
+  teams: { post: number };
+  docs: { docx: number; xlsx: number; txt: number; etc: number };
+  email: { receive: number; send: number };
+  git: { pull_request: number; commit: number; issue: number };
+}
+
+export interface ChartData {
+  email: { day: string; email: number; avg: number }[];
+  git: { day: string; git: number; avg: number }[];
+  docs: { day: string; docs: number; avg: number }[];
+  teams: { day: string; teams: number; avg: number }[];
+}


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 작업 내용

- [x] 일일 업무 총합 그래프 구현
- [x] 일일 업무 평균 비교 그래프 구현

## 스크린샷 (선택)
| 설명 | 이미지 |
|------------------|-------------|
| 개인 대시보드 화면 | <img width="1136" alt="image" src="https://github.com/user-attachments/assets/f237fd9a-bf5a-4437-b01a-650f291ae47a" />|

## 💬 리뷰 요구사항 or 추가 코멘트(선택)

> types 디렉토리에 통계 type interface 추가했습니다
> charts 디렉토리 아래에 _utils 생성하여 data 변환 함수 넣어놨습니다.
