### PR TITLE
feat: [#126] 데일리 보고서 UI/UX 개선

### DIFF
--- a/src/app/(app)/(member)/daily/[id]/_components/DailyReport.tsx
+++ b/src/app/(app)/(member)/daily/[id]/_components/DailyReport.tsx
@@ -8,7 +8,7 @@ import { ReportHeader } from "./ReportHeader";
  */
 export default function DailyReport({ title, report }: DailyReportData) {
   return (
-    <div className='min-h-screen bg-muted w-full max-w-5xl rounded-lg mx-auto py-8 px-4 sm:px-6 lg:px-16'>
+    <div className='min-h-screen bg-background w-full max-w-5xl rounded-lg mx-auto py-8 px-4 sm:px-6 lg:px-16'>
       {/* 헤더 */}
       <ReportHeader
         title={report.report_title}

--- a/src/app/(app)/(member)/daily/[id]/_components/ReportContent.tsx
+++ b/src/app/(app)/(member)/daily/[id]/_components/ReportContent.tsx
@@ -9,6 +9,10 @@ import {
 } from "@/components/ui/tooltip";
 import { ReportItem } from "@/types/reportType";
 import { formatBoldText } from "@/utils/formatBoldText";
+import {
+  formatBoldText as formatBoldTextNew,
+  formatToReadableList,
+} from "@/utils/formatReadableText";
 import { getSourceIcon } from "@/utils/getSourceIcon";
 
 interface ReportContentProps {
@@ -19,6 +23,65 @@ interface ReportContentProps {
 const removeWbsPrefix = (text: string) => {
   return text.replace("[WBS 매칭]", "").replace("[WBS 미매칭]", "");
 };
+
+const renderSafeContent = (
+  content: any,
+  bulletSymbol: string = "•",
+  marginClass: string = ""
+) => {
+  if (!content) {
+    return (
+      <p className='text-sm text-muted-foreground italic'>내용이 없습니다.</p>
+    );
+  }
+
+  const contentStr = String(content).trim();
+  if (!contentStr) {
+    return (
+      <p className='text-sm text-muted-foreground italic'>
+        내용이 비어있습니다.
+      </p>
+    );
+  }
+
+  const formattedItems = formatToReadableList(contentStr);
+
+  if (formattedItems.length == 0) {
+    return (
+      <p className='text-sm text-muted-foreground leading-relaxed'>
+        {formatBoldTextNew(contentStr)}
+      </p>
+    );
+  }
+
+  return (
+    <div className={`text-sm text-muted-foreground space-y-2 ${marginClass}`}>
+      {formattedItems.map((item, idx) => (
+        <div key={idx} className='pl-4 relative leading-relaxed'>
+          <span className='absolute left-0 top-1 text-xs'>{bulletSymbol}</span>
+          <span>{formatBoldTextNew(item)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// 섹션 헤더 렌더링 헬퍼 함수
+const renderSectionHeader = (
+  icon: string,
+  title: string,
+  subtitle?: string
+) => (
+  <div className='flex items-start gap-3'>
+    <div className='mt-0.5 w-6 h-6 flex items-center justify-center flex-shrink-0 text-base'>
+      {icon}
+    </div>
+    <div className='flex-1'>
+      <p className='font-semibold text-popover-foreground mb-1'>{title}</p>
+      {subtitle && <p className='text-sm text-muted-foreground'>{subtitle}</p>}
+    </div>
+  </div>
+);
 
 /**
  * 보고서 콘텐츠 컴포넌트
@@ -72,37 +135,23 @@ export function ReportContent({ contents }: ReportContentProps) {
                       </span>
                     </Badge>
                   </TooltipTrigger>
-                  <TooltipContent className='bg-popover border border-border shadow-lg text-sm px-4 py-3 max-w-md'>
+                  <TooltipContent className='bg-popover border border-border shadow-lg text-sm px-4 py-3 max-w-lg'>
                     <div className='space-y-3'>
-                      <div className='flex items-start gap-2'>
-                        <div className='mt-0.5'>📋</div>
-                        <div>
-                          <p className='font-semibold text-popover-foreground'>
-                            출처
-                          </p>
-                          <p className='text-sm text-muted-foreground'>
-                            {ev.title}
-                          </p>
-                        </div>
+                      {/* 출처 섹션 */}
+                      {renderSectionHeader("📋", "출처", ev.title)}
+
+                      {/* 출처 내용 */}
+                      <div className='bg-muted/80 p-3 rounded'>
+                        {renderSafeContent(ev.content)}
                       </div>
 
-                      <div className='text-sm text-muted-foreground bg-muted p-2 rounded'>
-                        {ev.content}
-                      </div>
-
+                      {/* AI 분석 근거 */}
                       {ev.llm_reference && (
                         <>
-                          <div className='border-t border-border'></div>
-                          <div className='flex items-start gap-2'>
-                            <div className='text-muted-foreground'>🤖</div>
-                            <div>
-                              <p className='font-semibold text-popover-foreground mb-1'>
-                                AI 분석 근거
-                              </p>
-                              <p className='text-sm text-muted-foreground leading-relaxed'>
-                                {ev.llm_reference}
-                              </p>
-                            </div>
+                          <div className='border-t border-border/50'></div>
+                          {renderSectionHeader("🤖", "AI 분석 근거")}
+                          <div className='bg-muted/80 p-3 rounded'>
+                            {renderSafeContent(ev.llm_reference, "▸", "-ml-0")}
                           </div>
                         </>
                       )}
@@ -118,7 +167,7 @@ export function ReportContent({ contents }: ReportContentProps) {
   );
 
   return (
-    <section className='bg-muted/20'>
+    <section className='bg-transparent'>
       <div className='max-w-3xl mx-auto px-8 py-6'>
         {/* 프로젝트별 섹션 렌더링 */}
         {Object.entries(projectGroups).map(
@@ -136,7 +185,7 @@ export function ReportContent({ contents }: ReportContentProps) {
               </div>
 
               {/* 작업 목록 */}
-              <div className='bg-muted-80 rounded-lg px-4'>
+              <div className='bg-muted/10 border border-border/50 rounded-lg px-4'>
                 <div className='space-y-0'>
                   {items.map((item, index) => renderTaskItem(item, index))}
                 </div>

--- a/src/app/(app)/(member)/daily/[id]/_components/ReportContent.tsx
+++ b/src/app/(app)/(member)/daily/[id]/_components/ReportContent.tsx
@@ -108,10 +108,12 @@ export function ReportContent({ contents }: ReportContentProps) {
           <ul className='list-disc pl-5 space-y-2'>
             <li className='text-foreground leading-relaxed'>
               <div className='flex flex-col'>
-                <span>{formatBoldText(removeWbsPrefix(item.text))}</span>
+                <span className='text-l font-bold'>
+                  {formatBoldText(removeWbsPrefix(item.text))}
+                </span>
                 {item.task && (
-                  <span className='font-medium text-sm text-foreground mt-1'>
-                    <span className='text-muted-foreground'>Task: </span>
+                  <span className='text-muted-foreground font-medium text-sm'>
+                    <span>Matched Task: </span>
                     {item.task}
                   </span>
                 )}

--- a/src/app/(app)/(member)/daily/[id]/_components/ReportContent.tsx
+++ b/src/app/(app)/(member)/daily/[id]/_components/ReportContent.tsx
@@ -168,7 +168,7 @@ export function ReportContent({ contents }: ReportContentProps) {
 
   return (
     <section className='bg-transparent'>
-      <div className='max-w-3xl mx-auto px-8 py-6'>
+      <div className='max-w-4xl mx-auto px-8 py-8'>
         {/* 프로젝트별 섹션 렌더링 */}
         {Object.entries(projectGroups).map(
           ([projectName, items], groupIndex) => (

--- a/src/app/(app)/(member)/daily/[id]/page.tsx
+++ b/src/app/(app)/(member)/daily/[id]/page.tsx
@@ -44,7 +44,7 @@ export default function DailyReportDetailPage() {
   }
 
   return (
-    <div className='space-y-6'>
+    <div className='space-y-6 bg-muted/100'>
       {/* 클라이언트 컴포넌트 - 액션 버튼들 */}
       <ReportActions
         backHref='/daily'

--- a/src/components/reports/ReportActions.tsx
+++ b/src/components/reports/ReportActions.tsx
@@ -38,7 +38,11 @@ export function ReportActions({
     <div className={`flex items-center justify-between p-6 pb-0 ${className}`}>
       <div className='flex items-center space-x-4'>
         <Link href={backHref}>
-          <Button variant='outline' size='sm'>
+          <Button
+            variant='outline'
+            size='sm'
+            className='hover:bg-primary hover:text-primary-foreground hover:border-primary transition-colors duration-200'
+          >
             <ArrowLeft className='mr-2 h-4 w-4' />
             {backButtonText}
           </Button>

--- a/src/utils/formatReadableText.tsx
+++ b/src/utils/formatReadableText.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+/**
+ * 긴 텍스트를 읽기 쉬운 구조로 변환하는 유틸 함수
+ */
+
+/**
+ * 텍스트를 구조화된 리스트로 변환
+ * - feat:, refactor:, fix: 등으로 시작하는 항목들을 분리
+ * - 긴 문장을 자연스럽게 분리
+ */
+export const formatToReadableList = (text: any): string[] => {
+  // 타입 가드: text가 문자열인지 확인
+  if (typeof text !== 'string' || !text || text.trim().length === 0) {
+    return [];
+  }
+  
+  // 1. Git 커밋 메시지 스타일 분리 (feat:, refactor:, fix: 등)
+  const gitPatterns = /(?:^|\s)(feat|refactor|fix|add|update|remove|improve|chore|docs|style|test|build|ci|perf|revert):/gi;
+  
+  if (gitPatterns.test(text)) {
+    return text
+      .split(/(?=(?:feat|refactor|fix|add|update|remove|improve|chore|docs|style|test|build|ci|perf|revert):)/gi)
+      .map(item => item.trim())
+      .filter(item => item.length > 0)
+      .map(item => item.replace(/^(feat|refactor|fix|add|update|remove|improve|chore|docs|style|test|build|ci|perf|revert):/i, (match) => 
+        `**${match}**`
+      ));
+  }
+  
+  // 2. 마침표나 세미콜론으로 구분된 문장 분리
+  const sentences = text
+    .split(/[.;]\s+/)
+    .map(sentence => sentence.trim())
+    .filter(sentence => sentence.length > 10); // 너무 짧은 문장 제거
+  
+  if (sentences.length > 1) {
+    return sentences;
+  }
+  
+  // 3. 쉼표로 구분된 항목들 (50자 이상일 때만)
+  if (text.length > 50 && text.includes(',')) {
+    const items = text
+      .split(',')
+      .map(item => item.trim())
+      .filter(item => item.length > 5);
+    
+    if (items.length > 1) {
+      return items;
+    }
+  }
+  
+  // 4. 기본값: 원본 텍스트 반환
+  return [text];
+};
+
+/**
+ * 볼드 텍스트 포맷팅 (기존 함수와 호환)
+ */
+export const formatBoldText = (text: any) => {
+  // 타입 가드: text가 문자열인지 확인
+  if (typeof text !== 'string' || !text) {
+    return text; // 문자열이 아니면 그대로 반환
+  }
+  
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+
+  return parts.map((part, index) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      const boldText = part.slice(2, -2);
+      return <strong key={index}>{boldText}</strong>;
+    }
+    return part;
+  });
+};


### PR DESCRIPTION



## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 작업 내용

- [x] 출처 및 AI 분석 근거 섹션 글머리 기호 추가 및 텍스트 간격 확대 (space-y-2)
- [x] 호버 효과 일관성 개선: 목록으로 버튼을 PDF 버튼 스타일로 통일
- [x] 브레드크럼에서 보고서 ID를 실제 날짜로 표시
- [x] 보고서 상세 페이지 배경색 개선 (흰색/회색)

## 스크린샷 (선택)



| 설명 | 이미지 |
|------------------|-------------|
| 데일리 보고서 상세 이미지 | ![image](https://github.com/user-attachments/assets/6418fcee-d971-4f79-942d-3765c3a2d9cc) |




